### PR TITLE
fix: prevent actuator protocol target duplication in AimRT v1.0.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 # Some option
 option(AIMRT_MUJOCO_SIM_BUILD_TESTS "AimRT Mujoco Sim build tests." OFF)
 option(AIMRT_MUJOCO_SIM_BUILD_EXAMPLES "AimRT Mujoco Sim build examples." OFF)
+option(AIMRT_MUJOCO_SIM_BUILD_ACTUATOR "AimRT Mujoco Sim build actuator." ON)
 option(AIMRT_MUJOCO_SIM_INSTALL "Enable installation of AimRT Mujoco Sim." ON)
 
 # Some necessary settings

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ cmake -B build \
     -DAIMRT_MUJOCO_SIM_BUILD_WITH_ROS2=ON \
     -DAIMRT_MUJOCO_SIM_BUILD_TESTS=OFF \
     -DAIMRT_MUJOCO_SIM_BUILD_EXAMPLES=ON \
+    -DAIMRT_MUJOCO_SIM_BUILD_ACTUATOR=ON \
     $@
 
 cmake --build build --config Release --target install --parallel $(nproc)

--- a/document/chapter1/chapter1_quickstart.md
+++ b/document/chapter1/chapter1_quickstart.md
@@ -32,7 +32,8 @@ Aimrt_Mujoco_Sim 旨在为机器人开发者提供一个快速上手的仿真平
   -DAIMRT_MUJOCO_SIM_INSTALL=ON \           # 是否生成安装包
   -DCMAKE_INSTALL_PREFIX=./build/install \  # 安装路径（默认：当前目录的 build/install）
   -DAIMRT_MUJOCO_SIM_BUILD_WITH_ROS2=ON \   # 是否启用 ROS2 支持, 默认为 OFF
-  -DAIMRT_MUJOCO_SIM_BUILD_EXAMPLES=ON      # 是否编译示例程序, 默认为 OFF
+  -DAIMRT_MUJOCO_SIM_BUILD_EXAMPLES=ON \    # 是否编译示例程序, 默认为 OFF
+  -DAIMRT_MUJOCO_SIM_BUILD_ACTUATOR=ON      # 是否编译 actuator protocol, 默认为 ON
 ```
 
 ### 1.2.3 运行 (run)

--- a/src/protocols/CMakeLists.txt
+++ b/src/protocols/CMakeLists.txt
@@ -3,7 +3,9 @@
 
 set_namespace()
 
+if(AIMRT_MUJOCO_SIM_BUILD_ACTUATOR)
 add_subdirectory(actuator)
+endif()
 
 if(AIMRT_MUJOCO_SIM_BUILD_EXAMPLES)
   add_subdirectory(examples/inverted_pendulum)


### PR DESCRIPTION
fix: prevent duplicate target creation for aimrt_protocols_actuator_pb_gencode in AimRT v1.0.0+(The relevant documents have been updated synchronously).

Problem: AimRT v1.0.0+ integrated the actuator protocol into its source code, causing CMake duplicate target error when building with the aimrt_mujoco_sim: "add_library cannot create target aimrt_protocols_actuator_pb_gencode because another target with the same name already exists".

Solution: Add conditional compilation in the CMakeLists.txt for actuator  protocol.